### PR TITLE
Support for Docker Registry v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM quay.io/aptible/ubuntu:14.04
+FROM quay.io/aptible/alpine:latest
 
 # Install NGiNX.
-RUN apt-get update
-RUN apt-get install -y software-properties-common \
-    python-software-properties && \
-    add-apt-repository -y ppa:nginx/stable && apt-get update && \
-    apt-get -y install curl ucspi-tcp apache2-utils nginx ruby
+RUN apk-install apache2-utils curl nginx openssl ruby
+
+# Ensure that the nginx user can write to temp paths like client_body_temp_path.
+RUN chown -R nginx:nginx /var/lib/nginx
 
 # Overwrite default nginx config with our config.
-RUN rm /etc/nginx/sites-enabled/*
+RUN mkdir -p /etc/nginx/sites-enabled
+ADD nginx.conf /etc/nginx/nginx.conf
 ADD templates/sites-enabled /
 
-# Add script that starts NGiNX in front of Kibana and tails the NGiNX access/error logs.
+# Add script that starts NGiNX in front of the registries and tails the NGiNX access/error logs.
 ADD bin .
 RUN chmod 700 ./run-docker-registry-proxy.sh
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,10 @@
 
 [![Docker Repository on Quay.io](https://quay.io/repository/aptible/registry-proxy/status)](https://quay.io/repository/aptible/registry-proxy)
 
-An NGiNX proxy for [Docker registries](https://github.com/docker/docker-registry)
-that terminates SSL and enforces HTTP basic authentication.
-
-## Background
-
-A Docker registry server lets you store and retrieve Docker images via
-`docker pull` and `docker push`. This repository builds a Docker container that
-runs NGiNX in front of such a registry server, handling SSL termination and
-enforcing HTTP basic authentication.
-
-This repository follows the [recommended Docker registry server NGiNX config for NGiNX 1.3.9 and later](https://github.com/docker/docker-registry/blob/master/contrib/nginx/nginx_1-3-9.conf) from the Docker registry server repo.
+A Docker image that runs an NGiNX proxy in front of
+[Docker registry v1](https://github.com/docker/docker-registry)
+or [Docker registry v2](https://github.com/docker/distribution),
+terminating SSL and enforcing HTTP basic authentication.
 
 ## Usage
 
@@ -26,20 +19,20 @@ Alternatively, you can build the image locally from this a clone of this repo by
 
 You need three things to run this proxy in front of a Docker registry:
 
-1. A running [Docker registry](https://github.com/docker/docker-registry).
+1. A running [Docker registry v1](https://github.com/docker/docker-registry) or
+[Docker registry v2](https://github.com/docker/distribution)
 2. A directory containing an SSL key pair.
-3. Auth Credentials
-* A comma-separated list of colon-delimited basic auth credentials, e.g., "user1:password1,user2:password2".
-* Or a htpasswd file created with htpasswd to be mounted
+3. Auth Credentials, in the form of either a comma-separated list of colon-delimited basic auth
+   credentials, e.g., "user1:password1,user2:password2" or an htpasswd file.
 
 Once you have everything in the list above, you can launch the registry proxy container. Here's an
-example:
-
-With comma-separated list of credentials:
+example of launching in front of a v2 registry:
 
 ```bash
-# Run the Docker registry as a 'local' registry with images stored in /tmp.
-docker run -itd --name docker-registry -P -e SETTINGS_FLAVOR=local registry
+REGISTRY_TAG="2"  # The Docker registry v2 repo on Docker Hub is "registry:2"
+
+# Run the Docker registry v2 as a 'local' registry with images stored in /tmp
+docker run -d --name docker-registry -P -v /tmp:/var/lib/registry "registry:$REGISTRY_TAG"
 
 # EXTERNAL_PORT is the port where this proxy (and therefore, the registry) will be exposed.
 EXTERNAL_PORT=46022
@@ -52,18 +45,25 @@ AUTH_CREDENTIALS=admin:admin123
 
 # Run the registry proxy container. The registry container must be linked in as
 # 'registry' to allow the proxy to discover the address it's listening to.
-docker run -itd --link docker-registry:registry \
-    -p "$EXTERNAL_PORT":443 \
-    -e AUTH_CREDENTIALS=$AUTH_CREDENTIALS \
-    -v $KEYPAIR_DIRECTORY:/etc/nginx/ssl \
+docker run -d \
+    --link docker-registry:registry \
+    -p "$EXTERNAL_PORT:443" \
+    -e "AUTH_CREDENTIALS=$AUTH_CREDENTIALS" \
+    -e "DOCKER_REGISTRY_TAG=$REGISTRY_TAG" \
+    -v "$KEYPAIR_DIRECTORY:/etc/nginx/ssl" \
     quay.io/aptible/registry-proxy
 ```
 
-If you would rather use an htpasswd file directly:
+Launching in front of a v1 registry is similar:
 
 ```bash
+REGISTRY_TAG="latest"  # You can also omit REGISTRY_TAG if proxying to the v1 registry.
+
 # Run the Docker registry as a 'local' registry with images stored in /tmp.
-docker run -itd --name docker-registry -P -e SETTINGS_FLAVOR=local registry
+docker run -d --name docker-registry -P -e SETTINGS_FLAVOR=local "registry:$REGISTRY_TAG"
+
+# Run the Docker registry v2 as a 'local' registry with images stored in /tmp
+docker run -d --name docker-registry-v2 -P -v /tmp:/var/lib/registry registry:2
 
 # EXTERNAL_PORT is the port where this proxy (and therefore, the registry) will be exposed.
 EXTERNAL_PORT=46022
@@ -71,17 +71,26 @@ EXTERNAL_PORT=46022
 # KEYPAIR_DIRECTORY should contain a .crt and .key.
 KEYPAIR_DIRECTORY=/tmp/my-certs
 
-# CREDENTIALS_LOCATION absolute path to credentials file
-CREDENTIALS_LOCATION=/tmp/my-passwords.htpasswd
+# AUTH_CREDENTIALS contains one or more user:password pairs, separated by commas.
+AUTH_CREDENTIALS=admin:admin123
 
 # Run the registry proxy container. The registry container must be linked in as
 # 'registry' to allow the proxy to discover the address it's listening to.
-docker run -itd --link docker-registry:registry \
-    -p "$EXTERNAL_PORT":443 \
-    -v $CREDENTIALS_LOCATION:/etc/nginx/conf.d/docker-registry-proxy.htpasswd \
-    -v $KEYPAIR_DIRECTORY:/etc/nginx/ssl \
+docker run -d \
+    --link docker-registry:registry \
+    -p "$EXTERNAL_PORT:443" \
+    -e "AUTH_CREDENTIALS=$AUTH_CREDENTIALS" \
+    -e "DOCKER_REGISTRY_TAG=$REGISTRY_TAG"
+    -v "$KEYPAIR_DIRECTORY:/etc/nginx/ssl" \
     quay.io/aptible/registry-proxy
 ```
+
+If you would rather use an htpasswd file directly, omit the `AUTH_CREDENTIALS`
+environment variable and mount the htpasswd file into the container as a volume
+at `/etc/nginx/conf.d/docker-registry-proxy.htpasswd`. For example, if your
+local htpasswd file is at /tmp/my-passwords.htpasswd, add the argument
+`-v /tmp/my-passwords.htpasswd:/etc/nginx/conf.d/docker-registry-rpoxy.htpasswd`
+to the final `docker run` command that brings up the registry proxy.
 
 ## Deployment
 
@@ -93,13 +102,13 @@ The `master` branch of this repo is deployed to the "staging" OpsWorks stack upo
 
 ### Credentials for CI
 
-This repo contains a `.travis.yml` file that will automatically deploy the application to staging. 
-To do this, our AWS credentials and our quay.io credentials for the "deploy-opsworks" user are encrypted and stored on Travis. 
+This repo contains a `.travis.yml` file that will automatically deploy the application to staging.
+To do this, our AWS credentials and our quay.io credentials for the "deploy-opsworks" user are encrypted and stored on Travis.
 To update these credentials, run the following commands (inserting the credential values):
 
     echo AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... DOCKER_EMAIL=... DOCKER_USERNAME=... DOCKER_PASSWORD=... > .env
     cat .env | travis encrypt -r aptible/registry-proxy --split
-    
+
 Update .travis.yml with the output that the command produces. Make sure to prepend each `secure` line with a `-`, and insert
 these lines under the `global` section of the .travis.yml file. It should look something like this:
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+user nginx;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+        worker_connections 768;
+}
+
+http {
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+        gzip on;
+        gzip_disable "msie6";
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}

--- a/templates/sites-enabled/docker-registry-proxy-v2.erb
+++ b/templates/sites-enabled/docker-registry-proxy-v2.erb
@@ -1,0 +1,38 @@
+upstream docker-registry {
+  server <%= ENV['REGISTRY_SERVER'] %>;
+}
+
+server {
+  listen 443;
+  server_name <%= ENV['SERVER_NAME'] %>;
+
+  ssl on;
+  ssl_certificate <%= ENV['CERT_FILE'] %>;
+  ssl_certificate_key <%= ENV['KEY_FILE'] %>;
+
+  client_max_body_size 0; # disable any limits to avoid HTTP 413 for large image uploads
+
+  # required to avoid HTTP 411: see Issue #1486 (https://github.com/docker/docker/issues/1486)
+  chunked_transfer_encoding on;
+
+  # See https://github.com/docker/distribution/issues/460
+  add_header Docker-Distribution-API-Version registry/2.0 always;
+
+  location /v2/ {
+    # Do not allow connections from docker 1.5 and earlier
+    # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+      return 404;
+    }
+
+    auth_basic            "Restricted";
+    auth_basic_user_file  /etc/nginx/conf.d/docker-registry-proxy.htpasswd;
+
+    proxy_pass            http://docker-registry;
+    proxy_set_header      Host                            $http_host;   # required for docker client's sake
+    proxy_set_header      X-Real-IP                       $remote_addr; # pass on real client's IP
+    proxy_set_header      X-Forwarded-For                 $proxy_add_x_forwarded_for;
+    proxy_set_header      X-Forwarded-Proto               $scheme;
+    proxy_read_timeout    900;
+  }
+}

--- a/templates/sites-enabled/docker-registry-proxy.erb
+++ b/templates/sites-enabled/docker-registry-proxy.erb
@@ -48,4 +48,24 @@ server {
     proxy_set_header      Authorization  "";  # see https://github.com/dotcloud/docker-registry/issues/170
     proxy_read_timeout    900;
   }
+
+  location /v2/ {
+    # Do not allow connections from docker 1.5 and earlier
+    # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+      return 404;
+    }
+
+    # To add basic authentication to v2 use auth_basic setting plus add_header
+    auth_basic            "Restricted";
+    auth_basic_user_file  /etc/nginx/conf.d/docker-registry-proxy.htpasswd;
+    add_header            'Docker-Distribution-Api-Version' 'registry/2.0' always;
+
+    proxy_pass                          http://docker-registry;
+    proxy_set_header  Host              $http_host;   # required for docker client's sake
+    proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+    proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header  X-Forwarded-Proto $scheme;
+    proxy_read_timeout                  900;
+  }
 }

--- a/templates/sites-enabled/docker-registry-proxy.erb
+++ b/templates/sites-enabled/docker-registry-proxy.erb
@@ -48,24 +48,4 @@ server {
     proxy_set_header      Authorization  "";  # see https://github.com/dotcloud/docker-registry/issues/170
     proxy_read_timeout    900;
   }
-
-  location /v2/ {
-    # Do not allow connections from docker 1.5 and earlier
-    # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
-    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
-      return 404;
-    }
-
-    # To add basic authentication to v2 use auth_basic setting plus add_header
-    auth_basic            "Restricted";
-    auth_basic_user_file  /etc/nginx/conf.d/docker-registry-proxy.htpasswd;
-    add_header            'Docker-Distribution-Api-Version' 'registry/2.0' always;
-
-    proxy_pass                          http://docker-registry;
-    proxy_set_header  Host              $http_host;   # required for docker client's sake
-    proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
-    proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header  X-Forwarded-Proto $scheme;
-    proxy_read_timeout                  900;
-  }
 }

--- a/test/docker-registry-proxy.bats
+++ b/test/docker-registry-proxy.bats
@@ -7,31 +7,36 @@ setup() {
 }
 
 teardown() {
-  service nginx stop
+  /usr/sbin/nginx -s stop
+  pkill tail
   rm /etc/nginx/conf.d/docker-registry-proxy.htpasswd || true
   rm /etc/nginx/sites-enabled/docker-registry-proxy || true
   rm -rf /etc/nginx/ssl || true
   rm /var/log/nginx/access.log || true
   rm /var/log/nginx/error.log || true
-  pkill tcpserver || true
 }
 
-@test "docker-registry-proxy uses an nginx version >= 1.3.9" {
-  # We need at least 1.3.9 for built-in handling of chunked transfer encoding.
-  run dpkg --compare-versions `/usr/sbin/nginx -v 2>&1 | grep -oP "\d+.\d+.\d+"` ">=" "1.3.9"
+@test "docker-registry-proxy uses an nginx version >= 1.7.5" {
+  # We need at least 1.7.5 for built-in handling of chunked transfer encoding (1.3.9)
+  # and support for the "always" parameter in the "add_header" directive (1.7.5).
+  run apk-install dpkg && \
+      dpkg --compare-versions `/usr/sbin/nginx -v 2>&1 | grep -oE "\d+.\d+.\d+"` ">=" "1.7.5" &&
+      apk del dpkg
   [ "$status" -eq 0 ]
 }
 
 @test "docker-registry-proxy requires the AUTH_CREDENTIALS environment variable to be set" {
   export REGISTRY_PORT=tcp://172.17.0.70:5000
-  run timeout 1 /bin/bash run-docker-registry-proxy.sh
+  export DOCKER_REGISTRY_TAG=latest
+  run timeout -t 1 /bin/bash run-docker-registry-proxy.sh
   [ "$status" -eq 1 ]
   [[ "$output" =~ "AUTH_CREDENTIALS" ]]
 }
 
 @test "docker-registry-proxy requires the REGISTRY_PORT environment variable to be set" {
   export AUTH_CREDENTIALS=foobar:password
-  run timeout 1 /bin/bash run-docker-registry-proxy.sh
+  export DOCKER_REGISTRY_TAG=latest
+  run timeout -t 1 /bin/bash run-docker-registry-proxy.sh
   [ "$status" -eq 1 ]
   [[ "$output" =~ "REGISTRY_PORT" ]]
 }
@@ -39,8 +44,9 @@ teardown() {
 @test "docker-registry-proxy requires a key in /etc/nginx/ssl" {
   export AUTH_CREDENTIALS=foobar:password
   export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=latest
   rm /etc/nginx/ssl/docker-registry-proxy.key
-  run timeout 1 /bin/bash run-docker-registry-proxy.sh
+  run timeout -t 1 /bin/bash run-docker-registry-proxy.sh
   [ "$status" -eq 1 ]
   [[ "$output" =~ "No key file" ]]
 }
@@ -48,8 +54,9 @@ teardown() {
 @test "docker-registry-proxy returns an error if more than one key is provided" {
   export AUTH_CREDENTIALS=foobar:password
   export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=latest
   touch /etc/nginx/ssl/extra-key.key
-  run timeout 1 /bin/bash run-docker-registry-proxy.sh
+  run timeout -t 1 /bin/bash run-docker-registry-proxy.sh
   [ "$status" -eq 1 ]
   [[ "$output" =~ "Multiple key files" ]]
 }
@@ -57,8 +64,9 @@ teardown() {
 @test "docker-registry-proxy requires a certificate in /etc/nginx/ssl" {
   export AUTH_CREDENTIALS=foobar:password
   export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=latest
   rm /etc/nginx/ssl/docker-registry-proxy.crt
-  run timeout 1 /bin/bash run-docker-registry-proxy.sh
+  run timeout -t 1 /bin/bash run-docker-registry-proxy.sh
   [ "$status" -eq 1 ]
   [[ "$output" =~ "No certificate file" ]]
 }
@@ -66,8 +74,56 @@ teardown() {
 @test "docker-registry-proxy returns an error if more than one certificate is provided" {
   export AUTH_CREDENTIALS=foobar:password
   export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=latest
   touch /etc/nginx/ssl/extra-cert.crt
-  run timeout 1 /bin/bash run-docker-registry-proxy.sh
+  run timeout -t 1 /bin/bash run-docker-registry-proxy.sh
   [ "$status" -eq 1 ]
   [[ "$output" =~ "Multiple certificate files" ]]
+}
+
+@test "docker-registry-proxy configures a v1 registry proxy if DOCKER_REGISTRY_TAG is omitted" {
+  export AUTH_CREDENTIALS=foobar:password
+  export REGISTRY_PORT=tcp://172.17.0.70:5000
+  timeout -t 1 /bin/bash run-docker-registry-proxy.sh || true
+  run bash -c "ls /etc/nginx/sites-enabled | wc -l"
+  [[ "$output" == "1" ]]
+  run cat /etc/nginx/sites-enabled/docker-registry-proxy
+  [[ "$output" =~ "location /v1" ]]
+  [[ ! "$output" =~ "location /v2" ]]
+}
+
+@test "docker-registry-proxy configures a v1 registry proxy if DOCKER_REGISTRY_TAG=latest" {
+  export AUTH_CREDENTIALS=foobar:password
+  export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=latest
+  timeout -t 1 /bin/bash run-docker-registry-proxy.sh || true
+  run bash -c "ls /etc/nginx/sites-enabled | wc -l"
+  [[ "$output" == "1" ]]
+  run cat /etc/nginx/sites-enabled/docker-registry-proxy
+  [[ "$output" =~ "location /v1" ]]
+  [[ ! "$output" =~ "location /v2" ]]
+}
+
+@test "docker-registry-proxy configures a v2 registry proxy if DOCKER_REGISTRY_TAG=2" {
+  export AUTH_CREDENTIALS=foobar:password
+  export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=2
+  timeout -t 1 /bin/bash run-docker-registry-proxy.sh || true
+  run bash -c "ls /etc/nginx/sites-enabled | wc -l"
+  [[ "$output" == "1" ]]
+  run cat /etc/nginx/sites-enabled/docker-registry-proxy
+  [[ ! "$output" =~ "location /v1" ]]
+  [[ "$output" =~ "location /v2" ]]
+}
+
+@test "docker-registry-proxy configures a v2 registry proxy if DOCKER_REGISTRY_TAG=2.2" {
+  export AUTH_CREDENTIALS=foobar:password
+  export REGISTRY_PORT=tcp://172.17.0.70:5000
+  export DOCKER_REGISTRY_TAG=2.2
+  timeout -t 1 /bin/bash run-docker-registry-proxy.sh || true
+  run bash -c "ls /etc/nginx/sites-enabled | wc -l"
+  [[ "$output" == "1" ]]
+  run cat /etc/nginx/sites-enabled/docker-registry-proxy
+  [[ ! "$output" =~ "location /v1" ]]
+  [[ "$output" =~ "location /v2" ]]
 }


### PR DESCRIPTION
Adding support for proxying to the Docker Registry 2. The `registry` docker repo currently has three tags: `latest` (v1), `2` (v2), and `2.2` (v2). This image now supports proxying to any of those as long as the correct tag is passed in to a container run from this image as `DOCKER_REGISTRY_TAG`. More details are included in the updated README in this patch.

Replacing the base image of this repo with quay.io/aptible/alpine, which cuts the size of the final squashed image down to less than 10 MB.

/cc @flaccid: Thanks for the original /v2/ PR, I've based the implementation here off of it and included your commit.
